### PR TITLE
Fix toast rendering clearing other toasts

### DIFF
--- a/src/main/java/github/erb3/fabric/nohotbarlooping/CustomToast.java
+++ b/src/main/java/github/erb3/fabric/nohotbarlooping/CustomToast.java
@@ -32,6 +32,11 @@ public class CustomToast implements Toast {
     }
 
     @Override
+    public Object getType() {
+        return NoHotbarLooping.modid;
+    }
+
+    @Override
     public Visibility draw(DrawContext context, ToastManager manager, long currentTime) {
         if (!timeStarted) {
             start = currentTime;
@@ -51,5 +56,9 @@ public class CustomToast implements Toast {
         context.drawItem(icon, 8, 8);
 
         return currentTime - start >= duration ? Toast.Visibility.HIDE : Toast.Visibility.SHOW;
+    }
+
+    public void remove() {
+        this.start = Short.MIN_VALUE;
     }
 }

--- a/src/main/java/github/erb3/fabric/nohotbarlooping/NoHotbarLooping.java
+++ b/src/main/java/github/erb3/fabric/nohotbarlooping/NoHotbarLooping.java
@@ -5,7 +5,6 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.toast.Toast;
 import net.minecraft.client.toast.ToastManager;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.item.Item;
@@ -61,9 +60,9 @@ public class NoHotbarLooping implements ClientModInitializer {
             title = translate("toast.enabled").getString();
         }
 
-        Toast toast = new CustomToast(item, title, "- NoHotbarLooping");
-        toaster.clear();
-        toaster.add(toast);
+        CustomToast oldToast = toaster.getToast(CustomToast.class, NoHotbarLooping.modid);
+        if (oldToast != null) oldToast.remove();
+        toaster.add(new CustomToast(item, title, "- NoHotbarLooping"));
     }
 
     public static Text translate(String key) {


### PR DESCRIPTION
Changes how toasts render to only clear the mods toasts and not all.
For example if you got an advancement and then enabled the mod it would clear the advancement toasts.

Easy way to test this is do `/recipe give @s *` and then click the keybind

Fixes this by adding a remove method that sets the start time to negative max short so that it is always exceeding the removal time.