### PR TITLE
chore: 1.21.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.7-SNAPSHOT'
-    id 'io.github.juuxel.loom-quiltflower' version '1.10.0'
+    id 'fabric-loom' version '1.11-SNAPSHOT'
     id "com.modrinth.minotaur" version "2.+"
 }
 
@@ -48,13 +47,16 @@ java {
         toolchain.languageVersion = JavaLanguageVersion.of(21)
     }
 
-    archivesBaseName = project.archives_base_name
     withSourcesJar()
+}
+
+base {
+    archivesName = project.archives_base_name
 }
 
 jar {
     from("LICENSE") {
-        rename { "${it}_${project.archivesBaseName}" }
+        rename { "${it}_${project.base.archivesName}" }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 org.gradle.jvmargs=-Xmx3G
 
 # check these on https://linkie.shedaniel.me/dependencies
-minecraft_version=1.21.4
-yarn_version=1.21.4+build.4
-loader_version=0.16.9
-fabric_api_version=0.114.0+1.21.4
-cloth_version=17.0.144
-mod_menu_version=13.0.0-beta.1
+minecraft_version=1.21.9
+yarn_version=1.21.9+build.1
+loader_version=0.17.2
+fabric_api_version=0.134.0+1.21.9
+cloth_version=20.0.148
+mod_menu_version=16.0.0-rc.1
 
 mod_version=1.1.1
 archives_base_name=nohotbarlooping

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/github/erb3/fabric/nohotbarlooping/Config.java
+++ b/src/main/java/github/erb3/fabric/nohotbarlooping/Config.java
@@ -15,8 +15,7 @@ public class Config {
         try (FileWriter writer = new FileWriter(configFile)) {
             gson.toJson(NoHotbarLooping.shouldLoopHotbar, writer);
         } catch (IOException e) {
-            NoHotbarLooping.logger.error("Could not save No Hotbar Looping configuration!");
-            e.printStackTrace();
+            NoHotbarLooping.logger.error("Could not save No Hotbar Looping configuration!", e);
         }
     }
 
@@ -25,8 +24,7 @@ public class Config {
             NoHotbarLooping.shouldLoopHotbar = gson.fromJson(reader, Boolean.class);
         } catch (Exception e) {
             if (configFile.exists()) {
-                NoHotbarLooping.logger.error("No Hotbar Looping configuration file exists, but could not load.");
-                e.printStackTrace();
+                NoHotbarLooping.logger.error("No Hotbar Looping configuration file exists, but could not load.", e);
             } else {
                 NoHotbarLooping.logger.warn("No Hotbar Looping configuration file does not exist!");
             }

--- a/src/main/java/github/erb3/fabric/nohotbarlooping/CustomToast.java
+++ b/src/main/java/github/erb3/fabric/nohotbarlooping/CustomToast.java
@@ -1,10 +1,9 @@
 package github.erb3.fabric.nohotbarlooping;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.toast.Toast;
 import net.minecraft.client.toast.ToastManager;
 import net.minecraft.item.Item;
@@ -15,8 +14,8 @@ import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
 
 public class CustomToast implements Toast {
-    public static final int titleColor = 0xFFFFFF;
-    public static final int textColor = 0xD3D3D3;
+    public static final int titleColor = 0xFFFFFFFF;
+    public static final int textColor = 0xFFD3D3D3;
 
     private final ItemStack icon;
     private final Text title;
@@ -55,8 +54,7 @@ public class CustomToast implements Toast {
 
     @Override
     public void draw(DrawContext context, TextRenderer textRenderer, long currentTime) {
-        RenderSystem.setShaderColor(1, 1, 1, 1);
-        context.drawGuiTexture(RenderLayer::getGuiTextured, Identifier.ofVanilla("toast/advancement"), 0, 0, getWidth(), getHeight());
+        context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, Identifier.ofVanilla("toast/advancement"), 0, 0, getWidth(), getHeight());
 
         int x = 28;
         MinecraftClient mc = MinecraftClient.getInstance();

--- a/src/main/java/github/erb3/fabric/nohotbarlooping/NoHotbarLooping.java
+++ b/src/main/java/github/erb3/fabric/nohotbarlooping/NoHotbarLooping.java
@@ -10,6 +10,7 @@ import net.minecraft.client.util.InputUtil;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import org.lwjgl.glfw.GLFW;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +18,6 @@ import org.slf4j.LoggerFactory;
 public class NoHotbarLooping implements ClientModInitializer {
     public static MinecraftClient client;
     private static KeyBinding keyBinding;
-    private static ToastManager toaster;
 
     @SuppressWarnings("SpellCheckingInspection")
     public static final String modid = "nohotbarlooping";
@@ -29,13 +29,13 @@ public class NoHotbarLooping implements ClientModInitializer {
     public void onInitializeClient() {
         logger.info("Hello from No Hotbar Looping!");
         client = MinecraftClient.getInstance();
-        toaster = client.getToastManager();
+        KeyBinding.Category category = KeyBinding.Category.create(Identifier.of(modid, "keybinding.category"));
 
         keyBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding(
             modid + ".keybinding.name",
             InputUtil.Type.KEYSYM,
             GLFW.GLFW_KEY_PERIOD,
-            modid + ".keybinding.category"
+            category
         ));
 
         ClientTickEvents.END_CLIENT_TICK.register((client) -> {
@@ -60,6 +60,8 @@ public class NoHotbarLooping implements ClientModInitializer {
             title = translate("toast.enabled").getString();
         }
 
+        // Access the ToastManager here as the mod gets initialized before the field is assigned
+        ToastManager toaster = client.getToastManager();
         CustomToast oldToast = toaster.getToast(CustomToast.class, NoHotbarLooping.modid);
         if (oldToast != null) oldToast.remove();
         toaster.add(new CustomToast(item, title, "- NoHotbarLooping"));

--- a/src/main/java/github/erb3/fabric/nohotbarlooping/mixin/MouseMixin.java
+++ b/src/main/java/github/erb3/fabric/nohotbarlooping/mixin/MouseMixin.java
@@ -25,7 +25,7 @@ public class MouseMixin {
             return scrollUpdatesTo;
         }
 
-        int originalSlot = inv.selectedSlot;
+        int originalSlot = inv.getSelectedSlot();
         if (Math.abs(originalSlot - scrollUpdatesTo) > 1) {
             return originalSlot;
         }

--- a/src/main/resources/assets/nohotbarlooping/lang/en_us.json
+++ b/src/main/resources/assets/nohotbarlooping/lang/en_us.json
@@ -4,7 +4,7 @@
   "nohotbarlooping.config.enabled.name": "Loop hotbar",
   "nohotbarlooping.config.enabled.description": "If your hotbar should loop when you scroll to the end of it",
   "nohotbarlooping.keybinding.name": "Toggle hotbar looping",
-  "nohotbarlooping.keybinding.category": "No Hotbar Looping",
+  "key.category.nohotbarlooping.keybinding.category": "No Hotbar Looping",
   "nohotbarlooping.toast.enabled": "Hotbar looping disabled",
   "nohotbarlooping.toast.disabled": "Hotbar looping enabled"
 }


### PR DESCRIPTION
<!-- Provide a descriptive title -->
# Update to 1.21.9

### Changes:

<!-- List changes made -->
- compile against Minecraft 1.21.9
- update most dependencies
- Loom includes VineFlower as the default decompiler in recent versions. The VineFlower plugin is therefore removed.
- The colors used in `CustomToast` are now specified with an alpha value of `255`. Minecraft no longer sets the alpha value if the color isn't fully black.
- The `ToastManager` instance is no longer cached in a separate field. Minecraft only creates the `ToastManager` after the mod is initialized.
- Updated the translation key for the key category as minecraft now has a specific naming scheme for them.

You may of course choose to not skip versions between 1.21.4 and 1.21.9 in which case this PR may be useful for orientation regarding the necessary changes and potential pitfalls (e.g. the change regarding text color transparency).
